### PR TITLE
Fixed request_permissions: function() for Chrome/Chromium

### DIFF
--- a/jquery.html5_notification.js
+++ b/jquery.html5_notification.js
@@ -142,7 +142,7 @@
             // Because chrome needs a handler this ugly fix is inside the request permission function
             // jQuery 1.9 no longer has the $.browser so this check looks for chrome in the browser agent.
             var browserAgent = navigator.userAgent.toString().toLowerCase();
-            if (browserAgent.indexOf('chrome') === -1) {
+            if(/chrom(e|ium)/.test(browserAgent)) {
 
                 Notification.requestPermission(function () {
                     self.permissionHandler();


### PR DESCRIPTION
The if() to identfy Chrome browsers

``` javascript
if (browserAgent.indexOf('chrome') === -1) { ... }
```

Doesn't work (anymore?) and throws the following error to the JS-Console:

> Uncaught TypeError: Cannot read property 'appendTo' of undefined
>     > html5Notification.request_permission @ jquery.html5_notification.js:156

Therefore fixed the Chrome/Chromium identification that will work.
Credits: http://stackoverflow.com/a/6339535
